### PR TITLE
Prefer HTTP protocol for git checkout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
     "repositories": {
         "kitodo-presentation": {
-            "type": "vcs",
-            "url": "git@github.com:kitodo/kitodo-presentation.git"
+            "type": "git",
+            "url": "https://github.com/kitodo/kitodo-presentation.git"
         },
         "slub-web-ldp": {
-            "type": "vcs",
-            "url": "git@git.slub-dresden.de:slub-webseite/slub-web-ldp.git"
+            "type": "git",
+            "url": "https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git"
         },
         "0": {
             "type": "composer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c8c985a855c21ae595885677f6dd506",
+    "content-hash": "3440494e46284d6e9451a92cacd08a41",
     "packages": [
         {
             "name": "caseyamcl/phpoaipmh",
@@ -1171,7 +1171,7 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "git@github.com:kitodo/kitodo-presentation.git",
+                "url": "https://github.com/kitodo/kitodo-presentation.git",
                 "reference": "5b7677b7d9be41edd018092d469ab81c39d9771f"
             },
             "require": {
@@ -1887,7 +1887,7 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "git@git.slub-dresden.de:slub-webseite/slub-web-ldp.git",
+                "url": "https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git",
                 "reference": "6a07542c30735c22fef6c2395cc85553cc721703"
             },
             "require": {


### PR DESCRIPTION
Your way of including the Git repositories is correct. I prefer to include it by the HTTP protocol. This way, you do not need a key exchanged before. The disadvantage with the private SLUB GitLab is of course, you have to enter your credencials every time you call `composer update`.

It's of course my habit. Not sure, if it's the better way.