### PR TITLE
Use `slub_web_sachsendigital` on GitHub instead of private `slub-web-ldp` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ddev-sachsendigital
 
-> :warning: This project depends upon the `slub-web-ldp` TYPO3 extension, which is not publicly available yet.
-
 This repository provides a [DDEV](https://ddev.readthedocs.io/)-based development environment for Sachsen.Digital.
 
 ## Quick Start

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
             "type": "git",
             "url": "https://github.com/slub/slub_digitalcollections.git"
         },
-        "slub-web-ldp": {
+        "slub-web-sachsendigital": {
             "type": "git",
-            "url": "https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git"
+            "url": "https://github.com/slub/slub_web_sachsendigital.git"
         },
         "0": {
             "type": "composer",
@@ -48,7 +48,7 @@
         "typo3/cms-viewpage": "^9.5",
         "kitodo/presentation": "dev-master",
         "slub/slub-digitalcollections": "dev-master",
-        "slub/slub-web-ldp": "dev-master"
+        "slub/slub-web-sachsendigital": "dev-main"
     },
     "scripts": {
         "typo3-cms-scripts": [

--- a/composer.lock
+++ b/composer.lock
@@ -1172,7 +1172,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/kitodo/kitodo-presentation.git",
-                "reference": "5b7677b7d9be41edd018092d469ab81c39d9771f"
+                "reference": "8a96e40fe0122ff6ba1c374f9e3647eeeddcbc52"
             },
             "require": {
                 "caseyamcl/phpoaipmh": "^3.0",
@@ -1227,7 +1227,7 @@
                 "source": "https://github.com/kitodo/kitodo-presentation",
                 "docs": "https://docs.typo3.org/p/kitodo/presentation/master/en-us/"
             },
-            "time": "2021-08-19T13:04:10+00:00"
+            "time": "2021-09-20T20:55:50+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -1300,16 +1300,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.12.0",
+            "version": "v4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
+                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
+                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
                 "shasum": ""
             },
             "require": {
@@ -1350,9 +1350,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
             },
-            "time": "2021-07-21T10:44:31+00:00"
+            "time": "2021-09-20T12:20:58+00:00"
         },
         {
             "name": "psr/cache",
@@ -3835,20 +3835,20 @@
         },
         {
             "name": "typo3/cms-about",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/about.git",
-                "reference": "2e9a388f761b3e27f075f6ae9439dcb7cedeaab0"
+                "reference": "9e604e18fe5d3f01757d78c0d30dddf946a7c790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/about/zipball/2e9a388f761b3e27f075f6ae9439dcb7cedeaab0",
-                "reference": "2e9a388f761b3e27f075f6ae9439dcb7cedeaab0",
+                "url": "https://api.github.com/repos/TYPO3-CMS/about/zipball/9e604e18fe5d3f01757d78c0d30dddf946a7c790",
+                "reference": "9e604e18fe5d3f01757d78c0d30dddf946a7c790",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -3881,32 +3881,32 @@
             "description": "Shows info about TYPO3, installed extensions and a separate module for available modules.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/about/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/about/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-adminpanel",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/adminpanel.git",
-                "reference": "c31659ce447093a3057f09d9a911f64b4f7e038c"
+                "reference": "873ea8bc86973cb110bdb2d1c3eef17bd8f83c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/adminpanel/zipball/c31659ce447093a3057f09d9a911f64b4f7e038c",
-                "reference": "c31659ce447093a3057f09d9a911f64b4f7e038c",
+                "url": "https://api.github.com/repos/TYPO3-CMS/adminpanel/zipball/873ea8bc86973cb110bdb2d1c3eef17bd8f83c82",
+                "reference": "873ea8bc86973cb110bdb2d1c3eef17bd8f83c82",
                 "shasum": ""
             },
             "require": {
                 "psr/http-message": "^1.0",
                 "psr/http-server-handler": "^1.0",
                 "psr/http-server-middleware": "^1.0",
-                "typo3/cms-backend": "9.5.30",
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-fluid": "9.5.30",
-                "typo3/cms-frontend": "9.5.30",
+                "typo3/cms-backend": "9.5.31",
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-fluid": "9.5.31",
+                "typo3/cms-frontend": "9.5.31",
                 "typo3fluid/fluid": "^2.6.10"
             },
             "conflict": {
@@ -3946,27 +3946,27 @@
             "description": "The TYPO3 admin panel provides a panel with additional functionality in the frontend (Debugging, Caching, Preview...)",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/adminpanel/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/adminpanel/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-backend",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/backend.git",
-                "reference": "e5f353ee7fff5b622f3aa39f5e63f5af967d71bc"
+                "reference": "ffb3ac828056e2207b0b34a6848b22382ee8e913"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/e5f353ee7fff5b622f3aa39f5e63f5af967d71bc",
-                "reference": "e5f353ee7fff5b622f3aa39f5e63f5af967d71bc",
+                "url": "https://api.github.com/repos/TYPO3-CMS/backend/zipball/ffb3ac828056e2207b0b34a6848b22382ee8e913",
+                "reference": "ffb3ac828056e2207b0b34a6848b22382ee8e913",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-recordlist": "9.5.30"
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-recordlist": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4016,26 +4016,26 @@
             "description": "Classes for the TYPO3 backend.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/backend/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/backend/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-belog",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/belog.git",
-                "reference": "dd09b4cb9eb15cc99ec8dcd614e0dac132ecbe6a"
+                "reference": "0913c0ea4e4a6472a0cb1a7e8269bbd63d732569"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/dd09b4cb9eb15cc99ec8dcd614e0dac132ecbe6a",
-                "reference": "dd09b4cb9eb15cc99ec8dcd614e0dac132ecbe6a",
+                "url": "https://api.github.com/repos/TYPO3-CMS/belog/zipball/0913c0ea4e4a6472a0cb1a7e8269bbd63d732569",
+                "reference": "0913c0ea4e4a6472a0cb1a7e8269bbd63d732569",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4068,26 +4068,26 @@
             "description": "Displays backend log, both per page and system wide. Available as the module Tools>Log (system wide overview) and Web>Info/Log (page relative overview).",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/belog/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/belog/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-beuser",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/beuser.git",
-                "reference": "2e1990e2dfc47119cfc317ba3bb9a860a9fd9220"
+                "reference": "1da6a17d70e68fe370e66493afba309a31a2a3ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/2e1990e2dfc47119cfc317ba3bb9a860a9fd9220",
-                "reference": "2e1990e2dfc47119cfc317ba3bb9a860a9fd9220",
+                "url": "https://api.github.com/repos/TYPO3-CMS/beuser/zipball/1da6a17d70e68fe370e66493afba309a31a2a3ff",
+                "reference": "1da6a17d70e68fe370e66493afba309a31a2a3ff",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4120,9 +4120,9 @@
             "description": "Backend user administration and overview. Allows you to compare the settings of users and verify their permissions and see who is online.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/beuser/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/beuser/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-cli",
@@ -4234,16 +4234,16 @@
         },
         {
             "name": "typo3/cms-core",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/core.git",
-                "reference": "7a65ceb9d9aac6ae847693d1273672e77e61a280"
+                "reference": "d167aa730b54329d00791665e245787357beee6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/7a65ceb9d9aac6ae847693d1273672e77e61a280",
-                "reference": "7a65ceb9d9aac6ae847693d1273672e77e61a280",
+                "url": "https://api.github.com/repos/TYPO3-CMS/core/zipball/d167aa730b54329d00791665e245787357beee6b",
+                "reference": "d167aa730b54329d00791665e245787357beee6b",
                 "shasum": ""
             },
             "require": {
@@ -4274,14 +4274,14 @@
                 "symfony/http-foundation": "^4.2.9 || ^5.0",
                 "symfony/polyfill-intl-icu": "^1.6",
                 "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.2",
+                "symfony/polyfill-mbstring": "^1.16",
                 "symfony/routing": "^4.3",
                 "symfony/yaml": "^4.1",
                 "typo3/class-alias-loader": "^1.0",
                 "typo3/cms-cli": "^2.0",
                 "typo3/cms-composer-installers": "^2.0 || ^3.0",
-                "typo3/html-sanitizer": "^2.0.9",
-                "typo3/phar-stream-wrapper": "^3.1.6",
+                "typo3/html-sanitizer": "^2.0.11",
+                "typo3/phar-stream-wrapper": "^3.1.7",
                 "typo3fluid/fluid": "^2.6.10"
             },
             "conflict": {
@@ -4354,26 +4354,26 @@
             "description": "The core library of TYPO3.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/core/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/core/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-extbase",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/extbase.git",
-                "reference": "10f008b8e868e393674bb5effdeb1d495cae49d4"
+                "reference": "9d40ac43c149070359092b6a17be8a815481eeca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/10f008b8e868e393674bb5effdeb1d495cae49d4",
-                "reference": "10f008b8e868e393674bb5effdeb1d495cae49d4",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extbase/zipball/9d40ac43c149070359092b6a17be8a815481eeca",
+                "reference": "9d40ac43c149070359092b6a17be8a815481eeca",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4416,26 +4416,26 @@
             "description": "A framework to build extensions for TYPO3 CMS.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/extbase/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/extbase/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-extensionmanager",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/extensionmanager.git",
-                "reference": "abe766b92c62cb3c3cfcaed039d732cdd94643ac"
+                "reference": "279b6253ea86fecb8f4a56bbf7421749c5f27631"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/extensionmanager/zipball/abe766b92c62cb3c3cfcaed039d732cdd94643ac",
-                "reference": "abe766b92c62cb3c3cfcaed039d732cdd94643ac",
+                "url": "https://api.github.com/repos/TYPO3-CMS/extensionmanager/zipball/279b6253ea86fecb8f4a56bbf7421749c5f27631",
+                "reference": "279b6253ea86fecb8f4a56bbf7421749c5f27631",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4470,26 +4470,26 @@
             "description": "TYPO3 Extension Manager",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/extensionmanager/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/extensionmanager/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-felogin",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/felogin.git",
-                "reference": "bd52f0064c11136799290709cbccbb6c8d0e0c48"
+                "reference": "e09e9326dc001c57c185cc5c89efbbbe7372d73f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/bd52f0064c11136799290709cbccbb6c8d0e0c48",
-                "reference": "bd52f0064c11136799290709cbccbb6c8d0e0c48",
+                "url": "https://api.github.com/repos/TYPO3-CMS/felogin/zipball/e09e9326dc001c57c185cc5c89efbbbe7372d73f",
+                "reference": "e09e9326dc001c57c185cc5c89efbbbe7372d73f",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4522,26 +4522,26 @@
             "description": "A template-based plugin to log in Website Users in the Frontend",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/felogin/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/felogin/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-filelist",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/filelist.git",
-                "reference": "3e37ab9075968e4e58260654145d937b2f291d78"
+                "reference": "54fefc7212fd1b342c4bfbfc79a869521aa6fb46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/3e37ab9075968e4e58260654145d937b2f291d78",
-                "reference": "3e37ab9075968e4e58260654145d937b2f291d78",
+                "url": "https://api.github.com/repos/TYPO3-CMS/filelist/zipball/54fefc7212fd1b342c4bfbfc79a869521aa6fb46",
+                "reference": "54fefc7212fd1b342c4bfbfc79a869521aa6fb46",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4576,27 +4576,27 @@
             "description": "Listing of files in the directory",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/filelist/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/filelist/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-fluid",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid.git",
-                "reference": "b2869b0b8e2453007c145db12701a5276acceaf1"
+                "reference": "012a1422aa4d42254870dd8e8e134bd0adbbfcf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/b2869b0b8e2453007c145db12701a5276acceaf1",
-                "reference": "b2869b0b8e2453007c145db12701a5276acceaf1",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid/zipball/012a1422aa4d42254870dd8e8e134bd0adbbfcf8",
+                "reference": "012a1422aa4d42254870dd8e8e134bd0adbbfcf8",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-extbase": "9.5.30",
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-extbase": "9.5.31",
                 "typo3fluid/fluid": "^2.6.10"
             },
             "conflict": {
@@ -4638,28 +4638,28 @@
             "description": "Fluid is a next-generation templating engine which makes the life of extension authors a lot easier!",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/fluid/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/fluid/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-fluid-styled-content",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/fluid_styled_content.git",
-                "reference": "14f030b44c715b04562b91b083a5c74098ed669f"
+                "reference": "ea5ecb935cd592336881b51ae526251edcc64e10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/14f030b44c715b04562b91b083a5c74098ed669f",
-                "reference": "14f030b44c715b04562b91b083a5c74098ed669f",
+                "url": "https://api.github.com/repos/TYPO3-CMS/fluid_styled_content/zipball/ea5ecb935cd592336881b51ae526251edcc64e10",
+                "reference": "ea5ecb935cd592336881b51ae526251edcc64e10",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-fluid": "9.5.30",
-                "typo3/cms-frontend": "9.5.30"
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-fluid": "9.5.31",
+                "typo3/cms-frontend": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4692,28 +4692,28 @@
             "description": "A set of common content elements based on Fluid for Frontend output.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/fluid_styled_content/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/fluid_styled_content/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-form",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/form.git",
-                "reference": "552053000744229651fae741f1df8580fcb41f12"
+                "reference": "03558bec2cb66167983cfd6b90cfd037a14fc6a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/552053000744229651fae741f1df8580fcb41f12",
-                "reference": "552053000744229651fae741f1df8580fcb41f12",
+                "url": "https://api.github.com/repos/TYPO3-CMS/form/zipball/03558bec2cb66167983cfd6b90cfd037a14fc6a6",
+                "reference": "03558bec2cb66167983cfd6b90cfd037a14fc6a6",
                 "shasum": ""
             },
             "require": {
                 "psr/http-message": "^1.0",
                 "symfony/expression-language": "^4.1",
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4750,26 +4750,27 @@
             "description": "Form Library, Plugin and Editor",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/form/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/form/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-frontend",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/frontend.git",
-                "reference": "780660e629cd3ea4e156928fe8f65d2d84904f3d"
+                "reference": "3f081bc9264b07ec66fc32ad14e13c7aa78ab7bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/780660e629cd3ea4e156928fe8f65d2d84904f3d",
-                "reference": "780660e629cd3ea4e156928fe8f65d2d84904f3d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/3f081bc9264b07ec66fc32ad14e13c7aa78ab7bd",
+                "reference": "3f081bc9264b07ec66fc32ad14e13c7aa78ab7bd",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "symfony/polyfill-mbstring": "^1.16",
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4807,26 +4808,26 @@
             "description": "Classes for the frontend of TYPO3.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/frontend/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/frontend/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-impexp",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/impexp.git",
-                "reference": "cee00e4d4848f723322d8176f668b5b6b0a082ea"
+                "reference": "0f5ad7ae8f875e230b612e631d9c4bd16843a37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/cee00e4d4848f723322d8176f668b5b6b0a082ea",
-                "reference": "cee00e4d4848f723322d8176f668b5b6b0a082ea",
+                "url": "https://api.github.com/repos/TYPO3-CMS/impexp/zipball/0f5ad7ae8f875e230b612e631d9c4bd16843a37d",
+                "reference": "0f5ad7ae8f875e230b612e631d9c4bd16843a37d",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4859,26 +4860,26 @@
             "description": "Import and Export of records from TYPO3 in a custom serialized format (.T3D) for data exchange with other TYPO3 systems.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/impexp/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/impexp/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-info",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/info.git",
-                "reference": "51f3a41dc2595872e135114a456c11a57cb60966"
+                "reference": "fcaf15960d4c505111420637e01c4bbee7beaa91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/51f3a41dc2595872e135114a456c11a57cb60966",
-                "reference": "51f3a41dc2595872e135114a456c11a57cb60966",
+                "url": "https://api.github.com/repos/TYPO3-CMS/info/zipball/fcaf15960d4c505111420637e01c4bbee7beaa91",
+                "reference": "fcaf15960d4c505111420637e01c4bbee7beaa91",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4920,30 +4921,30 @@
             "description": "Shows various infos",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/info/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/info/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-install",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/install.git",
-                "reference": "67338d910a9debcabf076eeff32496a66cc94053"
+                "reference": "7f5ef68b74a9decb1aa08380224c6f872d7fd7d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/67338d910a9debcabf076eeff32496a66cc94053",
-                "reference": "67338d910a9debcabf076eeff32496a66cc94053",
+                "url": "https://api.github.com/repos/TYPO3-CMS/install/zipball/7f5ef68b74a9decb1aa08380224c6f872d7fd7d9",
+                "reference": "7f5ef68b74a9decb1aa08380224c6f872d7fd7d9",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.3.0",
                 "symfony/finder": "^4.1",
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-extbase": "9.5.30",
-                "typo3/cms-fluid": "9.5.30"
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-extbase": "9.5.31",
+                "typo3/cms-fluid": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -4978,26 +4979,26 @@
             "description": "The Install Tool mounted as the module Tools>Install in TYPO3.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/install/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/install/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-recordlist",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/recordlist.git",
-                "reference": "d096519417e1e73a73a671b29aeadca8589dc666"
+                "reference": "478d0fdee7138b202a03258df804942ea218c9e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/recordlist/zipball/d096519417e1e73a73a671b29aeadca8589dc666",
-                "reference": "d096519417e1e73a73a671b29aeadca8589dc666",
+                "url": "https://api.github.com/repos/TYPO3-CMS/recordlist/zipball/478d0fdee7138b202a03258df804942ea218c9e1",
+                "reference": "478d0fdee7138b202a03258df804942ea218c9e1",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5037,27 +5038,27 @@
             "description": "List of database-records",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/recordlist/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/recordlist/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-redirects",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/redirects.git",
-                "reference": "3f020b9772a1618dbe44894dbe6f8d9539a9594d"
+                "reference": "8ce5796e6773fb4d48bce4304795d4c4b7e666ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/redirects/zipball/3f020b9772a1618dbe44894dbe6f8d9539a9594d",
-                "reference": "3f020b9772a1618dbe44894dbe6f8d9539a9594d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/redirects/zipball/8ce5796e6773fb4d48bce4304795d4c4b7e666ba",
+                "reference": "8ce5796e6773fb4d48bce4304795d4c4b7e666ba",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-backend": "9.5.30",
-                "typo3/cms-core": "9.5.30",
+                "typo3/cms-backend": "9.5.31",
+                "typo3/cms-core": "9.5.31",
                 "typo3fluid/fluid": "^2.6.10"
             },
             "conflict": {
@@ -5092,26 +5093,26 @@
             "description": "Custom redirects in TYPO3.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/redirects/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/redirects/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-reports",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/reports.git",
-                "reference": "0cb3877fa89eb6debcaad96b75435c89953ee881"
+                "reference": "9de508c8c60b12047c38bc16f612de4d9c39982d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/reports/zipball/0cb3877fa89eb6debcaad96b75435c89953ee881",
-                "reference": "0cb3877fa89eb6debcaad96b75435c89953ee881",
+                "url": "https://api.github.com/repos/TYPO3-CMS/reports/zipball/9de508c8c60b12047c38bc16f612de4d9c39982d",
+                "reference": "9de508c8c60b12047c38bc16f612de4d9c39982d",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5152,26 +5153,26 @@
             "description": "The reports module groups several system reports.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/reports/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/reports/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-rte-ckeditor",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/rte_ckeditor.git",
-                "reference": "c774863c5799c76ce57bf277063edd4b33a8bbf6"
+                "reference": "3eade51cd8240882aafdf46eb86abd52e6e064a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/c774863c5799c76ce57bf277063edd4b33a8bbf6",
-                "reference": "c774863c5799c76ce57bf277063edd4b33a8bbf6",
+                "url": "https://api.github.com/repos/TYPO3-CMS/rte_ckeditor/zipball/3eade51cd8240882aafdf46eb86abd52e6e064a5",
+                "reference": "3eade51cd8240882aafdf46eb86abd52e6e064a5",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5207,26 +5208,26 @@
             "description": "Integration of CKEditor as Rich Text Editor.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/rte_ckeditor/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/rte_ckeditor/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-scheduler",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/scheduler.git",
-                "reference": "f3438098e696d41a7f6d9811f64dbedf3d8ffa65"
+                "reference": "93ed3d80a346a657bb03cf24f249ec22506a3401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/scheduler/zipball/f3438098e696d41a7f6d9811f64dbedf3d8ffa65",
-                "reference": "f3438098e696d41a7f6d9811f64dbedf3d8ffa65",
+                "url": "https://api.github.com/repos/TYPO3-CMS/scheduler/zipball/93ed3d80a346a657bb03cf24f249ec22506a3401",
+                "reference": "93ed3d80a346a657bb03cf24f249ec22506a3401",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5256,28 +5257,28 @@
             "description": "The TYPO3 Scheduler let's you register tasks to happen at a specific time",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/scheduler/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/scheduler/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-seo",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/seo.git",
-                "reference": "32dffb22db51222f18a570f9bb94c8b2715b8a40"
+                "reference": "f2d57d935fd44d3ab41ecf815969c136235ed495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/32dffb22db51222f18a570f9bb94c8b2715b8a40",
-                "reference": "32dffb22db51222f18a570f9bb94c8b2715b8a40",
+                "url": "https://api.github.com/repos/TYPO3-CMS/seo/zipball/f2d57d935fd44d3ab41ecf815969c136235ed495",
+                "reference": "f2d57d935fd44d3ab41ecf815969c136235ed495",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30",
-                "typo3/cms-extbase": "9.5.30",
-                "typo3/cms-frontend": "9.5.30"
+                "typo3/cms-core": "9.5.31",
+                "typo3/cms-extbase": "9.5.31",
+                "typo3/cms-frontend": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5310,26 +5311,26 @@
             "description": "SEO features for TYPO3.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/seo/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/seo/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-setup",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/setup.git",
-                "reference": "daa938c1a43752018a0b7235f925438b9b6403c5"
+                "reference": "714950daf3f7a55dfbaf0c0e3d16615344ceb94a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/setup/zipball/daa938c1a43752018a0b7235f925438b9b6403c5",
-                "reference": "daa938c1a43752018a0b7235f925438b9b6403c5",
+                "url": "https://api.github.com/repos/TYPO3-CMS/setup/zipball/714950daf3f7a55dfbaf0c0e3d16615344ceb94a",
+                "reference": "714950daf3f7a55dfbaf0c0e3d16615344ceb94a",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5362,26 +5363,26 @@
             "description": "Allows users to edit a limited set of options for their user profile, eg. preferred language and their name and email address.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/setup/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/setup/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-sys-note",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/sys_note.git",
-                "reference": "49fda88301faa1d9b1cb1ca8b1f4755e2f198df7"
+                "reference": "0474cba5f985e215de2ed2a69cea032b5cfa2096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/49fda88301faa1d9b1cb1ca8b1f4755e2f198df7",
-                "reference": "49fda88301faa1d9b1cb1ca8b1f4755e2f198df7",
+                "url": "https://api.github.com/repos/TYPO3-CMS/sys_note/zipball/0474cba5f985e215de2ed2a69cea032b5cfa2096",
+                "reference": "0474cba5f985e215de2ed2a69cea032b5cfa2096",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5414,26 +5415,26 @@
             "description": "Records with messages which can be placed on any page and contain instructions or other information related to a page or section.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/sys_note/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/sys_note/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-t3editor",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/t3editor.git",
-                "reference": "064192b31094fc99595824bd0255b131ae4a221d"
+                "reference": "991430c5202c3585e371a15423de448a5e9506b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/t3editor/zipball/064192b31094fc99595824bd0255b131ae4a221d",
-                "reference": "064192b31094fc99595824bd0255b131ae4a221d",
+                "url": "https://api.github.com/repos/TYPO3-CMS/t3editor/zipball/991430c5202c3585e371a15423de448a5e9506b1",
+                "reference": "991430c5202c3585e371a15423de448a5e9506b1",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5471,26 +5472,26 @@
             "description": "JavaScript-driven editor with syntax highlighting and codecompletion. Based on CodeMirror.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/t3editor/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/t3editor/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-tstemplate",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/tstemplate.git",
-                "reference": "299f592a08380e2c1e439ee077043afd1eafb018"
+                "reference": "ba05de226e84003e6386ee2efe660df61c1ab609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/299f592a08380e2c1e439ee077043afd1eafb018",
-                "reference": "299f592a08380e2c1e439ee077043afd1eafb018",
+                "url": "https://api.github.com/repos/TYPO3-CMS/tstemplate/zipball/ba05de226e84003e6386ee2efe660df61c1ab609",
+                "reference": "ba05de226e84003e6386ee2efe660df61c1ab609",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5523,26 +5524,26 @@
             "description": "Framework for management of TypoScript template records for the CMS frontend.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/tstemplate/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/tstemplate/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/cms-viewpage",
-            "version": "v9.5.30",
+            "version": "v9.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3-CMS/viewpage.git",
-                "reference": "7b778214e635885730c5cbb91e7e4515cbf97737"
+                "reference": "2420c2755b174403b43d87df91698e393d07d8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/7b778214e635885730c5cbb91e7e4515cbf97737",
-                "reference": "7b778214e635885730c5cbb91e7e4515cbf97737",
+                "url": "https://api.github.com/repos/TYPO3-CMS/viewpage/zipball/2420c2755b174403b43d87df91698e393d07d8b0",
+                "reference": "2420c2755b174403b43d87df91698e393d07d8b0",
                 "shasum": ""
             },
             "require": {
-                "typo3/cms-core": "9.5.30"
+                "typo3/cms-core": "9.5.31"
             },
             "conflict": {
                 "typo3/cms": "*"
@@ -5575,22 +5576,22 @@
             "description": "Shows the frontend webpage inside the backend frameset.",
             "homepage": "https://typo3.org",
             "support": {
-                "source": "https://github.com/TYPO3-CMS/viewpage/tree/v9.5.30"
+                "source": "https://github.com/TYPO3-CMS/viewpage/tree/v9.5.31"
             },
-            "time": "2021-08-16T12:12:11+00:00"
+            "time": "2021-09-21T08:48:08+00:00"
         },
         {
             "name": "typo3/html-sanitizer",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/html-sanitizer.git",
-                "reference": "b9267c3b19ae1271b6c3f676f287e778977ca324"
+                "reference": "2d6f51881a4a2f69541102cb5ff021ad8ea8fdd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/html-sanitizer/zipball/b9267c3b19ae1271b6c3f676f287e778977ca324",
-                "reference": "b9267c3b19ae1271b6c3f676f287e778977ca324",
+                "url": "https://api.github.com/repos/TYPO3/html-sanitizer/zipball/2d6f51881a4a2f69541102cb5ff021ad8ea8fdd4",
+                "reference": "2d6f51881a4a2f69541102cb5ff021ad8ea8fdd4",
                 "shasum": ""
             },
             "require": {
@@ -5626,9 +5627,9 @@
             "description": "HTML sanitizer aiming to provide XSS-safe markup based on explicitly allowed tags, attributes and values.",
             "support": {
                 "issues": "https://github.com/TYPO3/html-sanitizer/issues",
-                "source": "https://github.com/TYPO3/html-sanitizer/tree/v2.0.10"
+                "source": "https://github.com/TYPO3/html-sanitizer/tree/v2.0.11"
             },
-            "time": "2021-08-25T11:05:47+00:00"
+            "time": "2021-09-21T07:16:35+00:00"
         },
         {
             "name": "typo3/minimal",
@@ -5689,16 +5690,16 @@
         },
         {
             "name": "typo3/phar-stream-wrapper",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "60131cb573a1e478cfecd34e4ea38e3b31505f75"
+                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/60131cb573a1e478cfecd34e4ea38e3b31505f75",
-                "reference": "60131cb573a1e478cfecd34e4ea38e3b31505f75",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
+                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
                 "shasum": ""
             },
             "require": {
@@ -5738,9 +5739,9 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
-                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.6"
+                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.7"
             },
-            "time": "2020-11-07T09:06:16+00:00"
+            "time": "2021-09-20T19:19:13+00:00"
         },
         {
             "name": "typo3fluid/fluid",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdaaeb2dfe7b7796c0f43f158e5c124e",
+    "content-hash": "ce939ea0c1db8a5ee7eb2604dac87cf8",
     "packages": [
         {
             "name": "caseyamcl/phpoaipmh",
@@ -1873,12 +1873,12 @@
             "time": "2021-07-27T09:17:00+00:00"
         },
         {
-            "name": "slub/slub-web-ldp",
-            "version": "dev-master",
+            "name": "slub/slub-web-sachsendigital",
+            "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git",
-                "reference": "6a07542c30735c22fef6c2395cc85553cc721703"
+                "url": "https://github.com/slub/slub_web_sachsendigital.git",
+                "reference": "c7f1cb99a6b6d3b2526bc084bee43db9178fba58"
             },
             "require": {
                 "kitodo/presentation": "~3.2|dev-master",
@@ -1889,12 +1889,12 @@
             "type": "typo3-cms-extension",
             "extra": {
                 "typo3/cms": {
-                    "extension-key": "slub_web_ldp"
+                    "extension-key": "slub_web_sachsendigital"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Slub\\SlubWebLdp\\": "Classes/"
+                    "Slub\\SlubWebSachsendigital\\": "Classes/"
                 }
             },
             "license": [
@@ -1918,13 +1918,13 @@
                 }
             ],
             "description": "Templates, Styles and Configuration for Sachsen.Digital",
-            "homepage": "https://git.slub-dresden.de/slub-webseite/slub-web-ldp",
+            "homepage": "https://github.com/slub/slub_web_sachsendigital",
             "keywords": [
                 "TYPO3",
                 "extension",
-                "slub_web_ldp"
+                "slub_web_sachsendigital"
             ],
-            "time": "2021-05-07T15:31:28+00:00"
+            "time": "2021-09-22T08:22:03+00:00"
         },
         {
             "name": "solarium/solarium",
@@ -5842,7 +5842,7 @@
     "stability-flags": {
         "kitodo/presentation": 20,
         "slub/slub-digitalcollections": 20,
-        "slub/slub-web-ldp": 20
+        "slub/slub-web-sachsendigital": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -50,10 +50,12 @@ echo '!/public/.htaccess' >> .gitignore
 
 echo '/extensions' >> .gitignore
 
-ddev composer config repositories.kitodo-presentation vcs git@github.com:kitodo/kitodo-presentation.git
-ddev composer config repositories.slub-web-ldp vcs git@git.slub-dresden.de:slub-webseite/slub-web-ldp.git
+ddev composer config repositories.kitodo-presentation vcs https://github.com/kitodo/kitodo-presentation.git
+ddev composer config repositories.slub-digitalcollections vcs https://github.com/slub/slub_digitalcollections.git
+ddev composer config repositories.slub-web-ldp vcs https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git
 
 ddev composer require kitodo/presentation:dev-master
+ddev composer require slub/slub-digitalcollections:dev-master
 ddev composer require slub/slub-web-ldp:dev-master
 
 ddev typo3cms database:updateschema

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -52,11 +52,11 @@ echo '/extensions' >> .gitignore
 
 ddev composer config repositories.kitodo-presentation vcs https://github.com/kitodo/kitodo-presentation.git
 ddev composer config repositories.slub-digitalcollections vcs https://github.com/slub/slub_digitalcollections.git
-ddev composer config repositories.slub-web-ldp vcs https://git.slub-dresden.de/slub-webseite/slub-web-ldp.git
+ddev composer config repositories.slub-web-sachsendigital vcs https://github.com/slub/slub_web_sachsendigital.git
 
 ddev composer require kitodo/presentation:dev-master
 ddev composer require slub/slub-digitalcollections:dev-master
-ddev composer require slub/slub-web-ldp:dev-master
+ddev composer require slub/slub-web-sachsendigital:dev-master
 
 ddev typo3cms database:updateschema
 ```

--- a/scripts/ext-clone.sh
+++ b/scripts/ext-clone.sh
@@ -21,4 +21,4 @@ function clone_conf()
 
 clone_conf kitodo-presentation git@github.com:kitodo/kitodo-presentation.git
 clone_conf slub-digitalcollections git@github.com:slub/slub_digitalcollections.git
-clone_conf slub-web-ldp git@git.slub-dresden.de:slub-webseite/slub-web-ldp.git
+clone_conf slub-web-sachsendigital git@github.com:slub/slub_web_sachsendigital.git


### PR DESCRIPTION
This PR makes the necessary changes given that `slub-web-ldp` is renamed to `slub_web_sachsendigital` and published on GitHub (slub/slub_web_sachsendigital#1).

For now, I'm referencing my own fork. Once slub/slub_web_sachsendigital#1 is merged, I will update this PR.