### PR TITLE
Tweak DB scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,10 @@ ddev composer update
 
 ## Database Dump
 
-```bash
-# Cleanup running database to keep dumps tidy.
-# Note that this will log you out.
-./scripts/db-cleanup.sh
+You may use the utility script `db-precommit.sh` to cleanup the database and export a dump to `data/db.sql`. Note that doing this will log you out.
 
-# Dump into `data/db.sql`
-./scripts/db-export.sh
+```bash
+./scripts/db-precommit.sh
 ```
 
 If you find anything in the published database dump that should not be shared, please feel free to open an issue or a pull request.

--- a/scripts/db-cleanup.sh
+++ b/scripts/db-cleanup.sh
@@ -13,6 +13,10 @@ SET
 
 TRUNCATE TABLE db.be_sessions;
 
+UPDATE db.sys_registry
+SET entry_value=NULL
+WHERE entry_namespace='core' AND entry_key LIKE 'formProtectionSessionToken:%';
+
 TRUNCATE TABLE db.cache_treelist;
 TRUNCATE TABLE db.cf_adminpanel_requestcache;
 TRUNCATE TABLE db.cf_adminpanel_requestcache_tags;

--- a/scripts/db-precommit.sh
+++ b/scripts/db-precommit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SCRIPTDIR=$(dirname "$0")
+
+"$SCRIPTDIR/db-cleanup.sh"
+"$SCRIPTDIR/db-export.sh"


### PR DESCRIPTION
There now is a combined script for cleaning up and exporting, and the cleanup script also clears `formProtectionSessionToken`.